### PR TITLE
Update example code for compatibility with latest `TCP` library.

### DIFF
--- a/examples/simple/manifest.savi
+++ b/examples/simple/manifest.savi
@@ -10,6 +10,7 @@
     :depends on ByteStream
     :depends on IO
     :depends on OSError
+    :depends on IPAddress
 
   :dependency IO v0
     :from "github:savi-lang/IO"
@@ -21,3 +22,6 @@
 
   :transitive dependency OSError v0
     :from "github:savi-lang/OSError"
+
+  :transitive dependency IPAddress v0
+    :from "github:savi-lang/IPAddress"

--- a/examples/simple/src/Main.savi
+++ b/examples/simple/src/Main.savi
@@ -12,8 +12,9 @@
   :fun ref io_react(action IO.Action)
     case action == (
     | IO.Action.Opened |
-      @env.out.print("[Listener] Listening on port:")
-      @env.out.print(Inspect[@io.listen_port_number])
+      @env.out.print("[Listener] Listening on: \(
+        try (@io.listen_address_with_port_number! | "???")
+      )")
     | IO.Action.OpenFailed |
       @env.out.print("[Listener] Not listening:")
       @env.out.print(@io.listen_error.name)


### PR DESCRIPTION
As of https://github.com/savi-lang/TCP/pull/12 there is a new way of getting the TCP listener address and/or port number.